### PR TITLE
Feature/empty prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,3 +62,7 @@ Run with environment variables
 $ FOO_I=20 FOO_S=foofoo FOO_F=0.2FOO_B=true FOO_DCT="{key: 100.0}" FOO_LST="[1, 2, 3]" python foo.py
 Foo(i=20, s='foofoo', f=0.2, b=True, lst=[1, 2, 3], dct={'key': 100.0})
 ```
+
+Notes:
+- If `prefix` is not defined or set to `None`, the default prefix (`ENV_`) will be expected.
+- If `prefix` is set to the empty string `''`, no prefix will be expected in the environment variables.

--- a/test_envclasses.py
+++ b/test_envclasses.py
@@ -189,6 +189,19 @@ def test_load_env_with_prefix():
     assert h.i == 20
 
 
+def test_load_env_with_empty_prefix():
+    @envclass
+    @dataclass
+    class Hoge:
+        i: int
+
+    h = Hoge(i=10)
+    assert h.i == 10
+    os.environ['I'] = '30'
+    load_env(h, prefix='')
+    assert h.i == 30
+
+
 def test_is_enum():
     class SEnum(enum.Enum):
         s = 's'


### PR DESCRIPTION
By this change you can allow loading environment variables without prefix by running `load_env(h, prefix='')`. If no prefix is provided, or explicitly set to None, the default prefix will still be used.