### PR TITLE
Fix _load_enum when env var is missing

### DIFF
--- a/envclasses.py
+++ b/envclasses.py
@@ -213,7 +213,7 @@ def _load_enum(obj, f: Field, prefix: str) -> None:
         try:
             setattr(obj, f.name, f.type(nested_type(os.environ[name])))
             return
-        except ValueError:
+        except (KeyError, ValueError):
             continue
 
 


### PR DESCRIPTION
Hi and thanks for the useful library!
The code currently crashes if an attribute is specified as an Enum and the corresponding variable is not set in the environment, resulting in a `KeyError`. This PR fixes that.