### PR TITLE
Disable parsing of str type

### DIFF
--- a/envclasses/__init__.py
+++ b/envclasses/__init__.py
@@ -159,6 +159,8 @@ def envclass(_cls: type) -> type:
                     _load_dict(self, f, prefix)
                 elif is_enum(f.type):
                     _load_enum(self, f, prefix)
+                elif is_str(f.type):
+                    _load_str(self, f, prefix)
                 else:
                     _load_other(self, f, prefix)
 
@@ -251,6 +253,18 @@ def _load_enum(obj, f: Field, prefix: str) -> None:
             continue
 
 
+def _load_str(obj, f: Field, prefix: str) -> None:
+    """
+    Override str values by environment variables.
+    """
+    name = f'{prefix.upper()}{f.name.upper()}'
+    try:
+        value = os.environ[name]
+        setattr(obj, f.name, _to_value(value, f.type))
+    except KeyError:
+        pass
+
+
 def _load_other(obj, f: Field, prefix: str) -> None:
     """
     Override values by environment variables.
@@ -301,6 +315,13 @@ def is_dict(typ: Type) -> bool:
         return issubclass(get_origin(typ), dict)
     except TypeError:
         return isinstance(typ, dict)
+
+
+def is_str(typ: Type) -> bool:
+    """
+    Test if the type is `str`.
+    """
+    return issubclass(typ, str)
 
 
 def is_envclass(instance_or_class: Any) -> bool:

--- a/test_envclasses.py
+++ b/test_envclasses.py
@@ -202,6 +202,23 @@ def test_load_env_with_empty_prefix():
     assert h.i == 30
 
 
+def test_str():
+    @envclass
+    @dataclass
+    class Hoge:
+        date: str
+        text: str
+
+    h = Hoge(date='2021', text='a\nb')
+    assert h.date == '2021'
+    assert h.text == 'a\nb'
+    os.environ['DATE'] = '2022-01-01T22:00:00Z'
+    os.environ['TEXT'] = 'c\nd'
+    load_env(h, prefix='')
+    assert h.date == '2022-01-01T22:00:00Z'
+    assert h.text == 'c\nd'
+
+
 def test_is_enum():
     class SEnum(enum.Enum):
         s = 's'


### PR DESCRIPTION
Hi! 👋 

With this fix, we disable parsing of attributes of type `str` by the underlying Yaml loader.

### Why?

Because if an attribute is declared as `str`, we expect it to be exactly the same as it was set in the ENV variable.

### Examples

- Timestamps
Yaml parses timestamps as `datetime` objects. Converting them to `str` will result in getting the isoformat with space as separator:
`"2022-01-01T00:00:00Z"` -> `"2022-01-01 00:00:00.000"`
- Text with newline characters
Newline characters are removed from ENV variables by Yaml:
`"a\nb"` -> `"a b"`