### PR TITLE
fix missing type after @envclass in vscode

### DIFF
--- a/envclasses/__init__.py
+++ b/envclasses/__init__.py
@@ -132,13 +132,13 @@ class InvalidNumberOfElement(LoadEnvError):
     """
 
 
-def envclass(_cls: type) -> type:
+def envclass(_cls: T) -> T:
     """
     `envclass` decorator generates methods to loads field values from environment variables.
 
     """
     @functools.wraps(_cls)
-    def wrap(cls) -> type:
+    def wrap(cls):
         def load_env(self, _prefix: str = None) -> None:
             """
             Load attributes from environment variables.


### PR DESCRIPTION
fix the typing bug that the type of orginal class will become to `Any` after `@envclass` decoration, cause autocomplete not work.

![スクリーンショット 2022-05-30 10 26 45](https://user-images.githubusercontent.com/86184362/170901304-5d59b17c-d427-4b0e-88cd-a19073d1dd23.png)
