### PR TITLE
Skip adding a second underscore in ENV prefix

### DIFF
--- a/envclasses/__init__.py
+++ b/envclasses/__init__.py
@@ -157,7 +157,7 @@ def envclass(_cls: Type[T]) -> Type[T]:
             for f in fields(cls):
                 # If no prefix specified, use the default PREFIX.
                 prefix = _prefix if _prefix is not None else ENVCLASS_PREFIX
-                prefix += '_' if prefix else ''
+                prefix += '_' if prefix and not prefix.endswith('_') else ''
                 logger.debug(f'prefix={prefix}, type={f.type}')
 
                 f_type = _coalesce(f.type)

--- a/test_envclasses.py
+++ b/test_envclasses.py
@@ -202,6 +202,22 @@ def test_load_env_with_empty_prefix():
     assert h.i == 30
 
 
+def test_load_env_with_underscore_prefix():
+    @envclass
+    @dataclass
+    class Hoge:
+        i: int
+
+    h = Hoge(i=10)
+    assert h.i == 10
+    os.environ['A_I'] = '30'
+    os.environ['AB_I'] = '40'
+    load_env(h, prefix='A')
+    assert h.i == 30
+    load_env(h, prefix='AB_')
+    assert h.i == 40
+
+
 def test_str():
     @envclass
     @dataclass


### PR DESCRIPTION
Whether or not the prefix should include the trailing `_` character is mostly a matter of taste. In envclasses, the prefix is given without the underscore, which is added for each attribute name (e.g. with prefix `A` the ENV variable for attribute `i` would be `A_I`). However, in other libraries like [Pydantic](https://pydantic-docs.helpmanual.io/usage/settings/), the `_` is expected in the prefix.

In this PR, we change this behavior and skip adding a second `_` if the prefix already ends with `_`. This results in always having an underscore between the prefix and the attribute names, but not two.