### PR TITLE
Migrate to uv

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,10 +16,10 @@ jobs:
        uses: actions/setup-python@v6.2.0
        with:
          python-version: "3.14"
+     - name: Install uv
+       uses: astral-sh/setup-uv@v5
      - name: Install dependencies
-       run: |
-         pip install poetry
-         make setup
+       run: uv sync
      - name: Get PR number
        uses: jwalton/gh-find-current-pr@v1
        id: findPr

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,9 +22,9 @@ jobs:
       uses: actions/setup-python@v6.2.0
       with:
         python-version: ${{ matrix.python-version }}
+    - name: Install uv
+      uses: astral-sh/setup-uv@v5
     - name: Install dependencies
-      run: |
-        pip install poetry
-        make setup
+      run: uv sync
     - name: Run tests
       run: make test

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ __pycache__
 htmlcov
 Pipfile.lock
 poetry.lock
+uv.lock

--- a/Makefile
+++ b/Makefile
@@ -3,29 +3,29 @@
 all: setup test
 
 setup:
-	poetry install
-	poetry run pip list
+	uv sync
+	uv run pip list
 
 test: unittest lint typecheck
 
 unittest:
-	poetry run pytest --doctest-modules envclasses test_envclasses.py -v
+	uv run pytest --doctest-modules envclasses test_envclasses.py -v
 
 lint:
-	poetry run ruff check envclasses
-	poetry run ruff format --check envclasses
+	uv run ruff check envclasses
+	uv run ruff format --check envclasses
 
 typecheck:
-	poetry run ty check envclasses
+	uv run ty check envclasses
 
 fmt:
-	poetry run ruff format envclasses
-	poetry run ruff check --fix envclasses
+	uv run ruff format envclasses
+	uv run ruff check --fix envclasses
 
 docs:
-	poetry run pip install pdoc
-	poetry run pdoc -e envclasses=https://github.com/yukinarit/envclasses/envclasses/ envclasses -o docs
+	uv run pip install pdoc
+	uv run pdoc -e envclasses=https://github.com/yukinarit/envclasses/envclasses/ envclasses -o docs
 
 serve-docs:
-	poetry pip install pdoc
-	poetry run pdoc -e envclasses=https://github.com/yukinarit/envclasses/envclasses/ envclasses
+	uv run pip install pdoc
+	uv run pdoc -e envclasses=https://github.com/yukinarit/envclasses/envclasses/ envclasses

--- a/envclasses/__init__.py
+++ b/envclasses/__init__.py
@@ -78,6 +78,7 @@ import logging
 logging.getLogger("envclasses").setLevel(logging.DEBUG)
 ```
 """
+
 import enum
 import functools
 import logging
@@ -89,27 +90,27 @@ import yaml
 from typing_inspect import get_args, get_origin, is_optional_type
 
 __all__ = [
-    'envclass',
-    'is_envclass',
-    'load_env',
-    'EnvclassError',
-    'LoadEnvError',
+    "envclass",
+    "is_envclass",
+    "load_env",
+    "EnvclassError",
+    "LoadEnvError",
 ]
 
-__version__ = '0.2.7'
+__version__ = "0.2.7"
 """ Version of envclass. """
 
-logger = logging.getLogger('envclasses')
+logger = logging.getLogger("envclasses")
 
-ENVCLASS_DUNDER_FUNC_NAME = '__envclasses_load_env__'
+ENVCLASS_DUNDER_FUNC_NAME = "__envclasses_load_env__"
 """ Name of the generated dunder function to be called by `load_env`. """
 
-ENVCLASS_PREFIX = 'env'
+ENVCLASS_PREFIX = "env"
 """ Default prefix used for environment variables. """
 
-T = TypeVar('T')
+T = TypeVar("T")
 
-JsonValue = TypeVar('JsonValue', str, int, float, bool, Dict, List)
+JsonValue = TypeVar("JsonValue", str, int, float, bool, Dict, List)
 
 
 class EnvclassError(TypeError):
@@ -138,7 +139,8 @@ def _coalesce(typ: Type) -> Type:
     else:
         return cast(
             Type,
-            Union[tuple(tt for tt in get_args(typ, evaluate=True) if not is_optional_type(tt))])
+            Union[tuple(tt for tt in get_args(typ, evaluate=True) if not is_optional_type(tt))],
+        )
 
 
 def envclass(_cls: Type[T]) -> Type[T]:
@@ -157,8 +159,8 @@ def envclass(_cls: Type[T]) -> Type[T]:
             for f in fields(cls):
                 # If no prefix specified, use the default PREFIX.
                 prefix = _prefix if _prefix is not None else ENVCLASS_PREFIX
-                prefix += '_' if prefix and not prefix.endswith('_') else ''
-                logger.debug(f'prefix={prefix}, type={f.type}')
+                prefix += "_" if prefix and not prefix.endswith("_") else ""
+                logger.debug(f"prefix={prefix}, type={f.type}")
 
                 f_type = _coalesce(f.type)
                 if is_envclass(f_type):
@@ -186,7 +188,7 @@ def _load_dataclass(obj, f: Field, prefix: str, f_type: Optional[Type] = None) -
     """
     Override exisiting dataclass object by environment variables.
     """
-    inner_prefix = f'{prefix}{f.name}'
+    inner_prefix = f"{prefix}{f.name}"
     typ = f_type or f.type
     if getattr(obj, f.name, None) is None:
         setattr(obj, f.name, typ())
@@ -203,7 +205,7 @@ def _load_list(obj, f: Field, prefix: str, f_type: Optional[Type] = None) -> Non
     """
     typ = f_type or f.type
     element_type = typ.__args__[0]
-    name = f'{prefix.upper()}{f.name.upper()}'
+    name = f"{prefix.upper()}{f.name.upper()}"
     try:
         s: str = os.environ[name].strip()
     except KeyError:
@@ -219,7 +221,7 @@ def _load_tuple(obj, f: Field, prefix: str, f_type: Optional[Type] = None) -> No
     Override tuple values by environment variables.
     """
     typ = f_type or f.type
-    name = f'{prefix.upper()}{f.name.upper()}'
+    name = f"{prefix.upper()}{f.name.upper()}"
     element_types = typ.__args__
     try:
         s: str = os.environ[name].strip()
@@ -228,8 +230,7 @@ def _load_tuple(obj, f: Field, prefix: str, f_type: Optional[Type] = None) -> No
 
     lst = yaml.safe_load(s)
     if len(lst) != len(element_types):
-        raise InvalidNumberOfElement(f'expected={len(element_types)} '
-                                     f'actual={len(lst)}')
+        raise InvalidNumberOfElement(f"expected={len(element_types)} actual={len(lst)}")
     tpl = tuple(element_type(e) for e, element_type in zip(lst, element_types))
     setattr(obj, f.name, tpl)
 
@@ -239,7 +240,7 @@ def _load_dict(obj, f: Field, prefix: str, f_type: Optional[Type] = None) -> Non
     Override dict values by environment variables.
     """
     typ = f_type or f.type
-    name = f'{prefix.upper()}{f.name.upper()}'
+    name = f"{prefix.upper()}{f.name.upper()}"
     key_type = typ.__args__[0]
     value_type = typ.__args__[1]
     try:
@@ -259,7 +260,7 @@ def _to_value(v: JsonValue, typ: Type) -> Any:
 
 
 def _load_enum(obj, f: Field, prefix: str, f_type: Optional[Type] = None) -> None:
-    name = f'{prefix.upper()}{f.name.upper()}'
+    name = f"{prefix.upper()}{f.name.upper()}"
     typ = f_type or f.type
     for enum_item in list(typ):
         try:
@@ -273,7 +274,7 @@ def _load_str(obj, f: Field, prefix: str, f_type: Optional[Type] = None) -> None
     """
     Override str values by environment variables.
     """
-    name = f'{prefix.upper()}{f.name.upper()}'
+    name = f"{prefix.upper()}{f.name.upper()}"
     typ = f_type or f.type
     try:
         value = os.environ[name]
@@ -286,7 +287,7 @@ def _load_other(obj, f: Field, prefix: str, f_type: Optional[Type] = None) -> No
     """
     Override values by environment variables.
     """
-    name = f'{prefix.upper()}{f.name.upper()}'
+    name = f"{prefix.upper()}{f.name.upper()}"
     typ = f_type or f.type
     try:
         yml = yaml.safe_load(os.environ[name])

--- a/envclasses/__init__.py
+++ b/envclasses/__init__.py
@@ -84,7 +84,7 @@ import functools
 import logging
 import os
 from dataclasses import Field, fields
-from typing import Any, Dict, List, Optional, Type, TypeVar, Union, cast
+from typing import Any, Dict, List, Optional, Type, TypeVar, Union, cast, get_type_hints
 
 import yaml
 from typing_inspect import get_args, get_origin, is_optional_type
@@ -152,17 +152,18 @@ def envclass(_cls: Type[T]) -> Type[T]:
     @functools.wraps(_cls)
     def wrap(cls):
 
-        def load_env(self, _prefix: str = None) -> None:
+        def load_env(self, _prefix: Optional[str] = None) -> None:
             """
             Load attributes from environment variables.
             """
+            hints = get_type_hints(cls)
             for f in fields(cls):
                 # If no prefix specified, use the default PREFIX.
                 prefix = _prefix if _prefix is not None else ENVCLASS_PREFIX
                 prefix += "_" if prefix and not prefix.endswith("_") else ""
                 logger.debug(f"prefix={prefix}, type={f.type}")
 
-                f_type = _coalesce(f.type)
+                f_type = _coalesce(hints[f.name])
                 if is_envclass(f_type):
                     _load_dataclass(self, f, prefix, f_type)
                 elif is_list(f_type):
@@ -189,7 +190,7 @@ def _load_dataclass(obj, f: Field, prefix: str, f_type: Optional[Type] = None) -
     Override exisiting dataclass object by environment variables.
     """
     inner_prefix = f"{prefix}{f.name}"
-    typ = f_type or f.type
+    typ: Type = cast(Type, f_type or f.type)
     if getattr(obj, f.name, None) is None:
         setattr(obj, f.name, typ())
     o = getattr(obj, f.name)
@@ -203,8 +204,8 @@ def _load_list(obj, f: Field, prefix: str, f_type: Optional[Type] = None) -> Non
     """
     Override list values by environment variables.
     """
-    typ = f_type or f.type
-    element_type = typ.__args__[0]
+    typ: Type = cast(Type, f_type or f.type)
+    element_type = get_args(typ)[0]
     name = f"{prefix.upper()}{f.name.upper()}"
     try:
         s: str = os.environ[name].strip()
@@ -220,9 +221,9 @@ def _load_tuple(obj, f: Field, prefix: str, f_type: Optional[Type] = None) -> No
     """
     Override tuple values by environment variables.
     """
-    typ = f_type or f.type
+    typ: Type = cast(Type, f_type or f.type)
     name = f"{prefix.upper()}{f.name.upper()}"
-    element_types = typ.__args__
+    element_types = get_args(typ)
     try:
         s: str = os.environ[name].strip()
     except KeyError:
@@ -239,10 +240,11 @@ def _load_dict(obj, f: Field, prefix: str, f_type: Optional[Type] = None) -> Non
     """
     Override dict values by environment variables.
     """
-    typ = f_type or f.type
+    typ: Type = cast(Type, f_type or f.type)
     name = f"{prefix.upper()}{f.name.upper()}"
-    key_type = typ.__args__[0]
-    value_type = typ.__args__[1]
+    args = get_args(typ)
+    key_type = args[0]
+    value_type = args[1]
     try:
         s = os.environ[name].strip()
     except KeyError:
@@ -252,7 +254,7 @@ def _load_dict(obj, f: Field, prefix: str, f_type: Optional[Type] = None) -> Non
     setattr(obj, f.name, dct)
 
 
-def _to_value(v: JsonValue, typ: Type) -> Any:
+def _to_value(v: Any, typ: Type) -> Any:
     if isinstance(v, (List, Dict)):
         return v
     else:
@@ -261,10 +263,11 @@ def _to_value(v: JsonValue, typ: Type) -> Any:
 
 def _load_enum(obj, f: Field, prefix: str, f_type: Optional[Type] = None) -> None:
     name = f"{prefix.upper()}{f.name.upper()}"
-    typ = f_type or f.type
-    for enum_item in list(typ):
+    typ: Type[enum.Enum] = cast(Type[enum.Enum], f_type or f.type)
+    for enum_item in typ:
         try:
-            setattr(obj, f.name, typ(type(enum_item.value)(os.environ[name])))
+            value_type = type(enum_item.value)
+            setattr(obj, f.name, typ(cast(Any, value_type)(os.environ[name])))
             return
         except (KeyError, ValueError):
             continue
@@ -275,7 +278,7 @@ def _load_str(obj, f: Field, prefix: str, f_type: Optional[Type] = None) -> None
     Override str values by environment variables.
     """
     name = f"{prefix.upper()}{f.name.upper()}"
-    typ = f_type or f.type
+    typ: Type = cast(Type, f_type or f.type)
     try:
         value = os.environ[name]
         setattr(obj, f.name, _to_value(value, typ))
@@ -288,7 +291,7 @@ def _load_other(obj, f: Field, prefix: str, f_type: Optional[Type] = None) -> No
     Override values by environment variables.
     """
     name = f"{prefix.upper()}{f.name.upper()}"
-    typ = f_type or f.type
+    typ: Type = cast(Type, f_type or f.type)
     try:
         yml = yaml.safe_load(os.environ[name])
         setattr(obj, f.name, _to_value(yml, typ))
@@ -362,7 +365,7 @@ def is_envclass(instance_or_class: Any) -> bool:
     return hasattr(instance_or_class, ENVCLASS_DUNDER_FUNC_NAME)
 
 
-def load_env(inst, prefix: str = None) -> None:
+def load_env(inst, prefix: Optional[str] = None) -> None:
     """
     Load field values from environment variables.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,13 +1,12 @@
-[tool.poetry]
+[project]
 name = "envclasses"
 version = "0.3.1"
 description = "envclasses is a library to map fields on dataclass object to environment variables"
-authors = ["Yukinari Tani <yukinarit84@gmail.com>"]
-license = "MIT"
+authors = [{ name = "Yukinari Tani", email = "yukinarit84@gmail.com" }]
+license = { text = "MIT" }
 readme = "README.md"
-repository = "https://github.com/yukinarit/envclasses"
-homepage = "https://yukinarit.github.io/envclasses/envclasses.html"
-classifiers=[
+requires-python = ">=3.9"
+classifiers = [
     "Development Status :: 5 - Production/Stable",
     "Intended Audience :: Developers",
     "License :: OSI Approved :: MIT License",
@@ -19,16 +18,25 @@ classifiers=[
     "Programming Language :: Python :: 3.14",
     "Programming Language :: Python :: Implementation :: CPython",
 ]
+dependencies = [
+    "pyyaml",
+    "typing_inspect>=0.4.0",
+]
 
-[tool.poetry.dependencies]
-python = "^3.9"
-pyyaml = "*"
-typing_inspect = ">=0.4.0"
+[project.urls]
+Repository = "https://github.com/yukinarit/envclasses"
+Homepage = "https://yukinarit.github.io/envclasses/envclasses.html"
 
-[tool.poetry.dev-dependencies]
-pytest = "^8.0"
-ruff = "0.15.10"
-ty = "0.0.29"
+[dependency-groups]
+dev = [
+    "pytest>=8.0",
+    "ruff==0.15.10",
+    "ty==0.0.29",
+]
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
 
 [tool.ruff]
 target-version = "py39"
@@ -36,7 +44,3 @@ line-length = 100
 
 [tool.ruff.lint]
 select = ["E", "F", "I"]
-
-[build-system]
-requires = ["poetry-core>=1.0.0"]
-build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
Replace Poetry with uv for dependency management. Switch pyproject.toml to standard [project] / [dependency-groups] layout with hatchling build backend, update Makefile targets, and swap CI install steps to astral-sh/setup-uv@v5.