### PR TITLE
Derive version from git tags via hatch-vcs

### DIFF
--- a/envclasses/__init__.py
+++ b/envclasses/__init__.py
@@ -97,9 +97,6 @@ __all__ = [
     "LoadEnvError",
 ]
 
-__version__ = "0.2.7"
-""" Version of envclass. """
-
 logger = logging.getLogger("envclasses")
 
 ENVCLASS_DUNDER_FUNC_NAME = "__envclasses_load_env__"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "envclasses"
-version = "0.3.1"
+dynamic = ["version"]
 description = "envclasses is a library to map fields on dataclass object to environment variables"
 authors = [{ name = "Yukinari Tani", email = "yukinarit84@gmail.com" }]
 license = { text = "MIT" }
@@ -34,8 +34,11 @@ dev = [
     "ty==0.0.29",
 ]
 
+[tool.hatch.version]
+source = "vcs"
+
 [build-system]
-requires = ["hatchling"]
+requires = ["hatchling", "hatch-vcs"]
 build-backend = "hatchling.build"
 
 [tool.ruff]


### PR DESCRIPTION
Remove hardcoded __version__ from __init__.py and switch the hatchling version source to vcs (hatch-vcs). Version is now inferred from the nearest git tag.